### PR TITLE
Fix display on ultrawide resolutions

### DIFF
--- a/src/main/java/Bestiary/config/AlternateConfigPanel.java
+++ b/src/main/java/Bestiary/config/AlternateConfigPanel.java
@@ -14,10 +14,11 @@ import com.megacrit.cardcrawl.helpers.ImageMaster;
 
 public class AlternateConfigPanel extends ModPanel {
         private static Texture TEX_BG = new Texture("Bestiary/config.png");
+        private static final float startX = (Settings.WIDTH - (TEX_BG.getWidth() * Settings.scale)) * 0.5f;
 
         public AlternateConfigPanel() {
             addUIElement(new ModLabeledToggleButton("Require holding Shift to open overlay (prevents accidental openings)",
-                    395,
+                    startX + 79 * Settings.scale,
                     668,
                     ExtraColors.OJB_GRAY_COLOR,
                     FontHelper.tipBodyFont,
@@ -39,7 +40,7 @@ public class AlternateConfigPanel extends ModPanel {
             // Draw our screen texture in the center
             sb.setColor(Color.WHITE);
             sb.draw(TEX_BG,
-                    (Settings.WIDTH - (TEX_BG.getWidth() * Settings.scale)) * 0.5f,
+                    startX,
                     (Settings.HEIGHT - (TEX_BG.getHeight() * Settings.scale)) * 0.5f,
                     TEX_BG.getWidth() * Settings.scale,
                     TEX_BG.getHeight() * Settings.scale
@@ -51,13 +52,13 @@ public class AlternateConfigPanel extends ModPanel {
         super.render(sb);
 
         // Render title
-        FontHelper.renderFontLeftDownAligned(sb, ExtraFonts.overlayTitleFont(), "Bestiary", 395.0f * Settings.scale, 825.0f * Settings.scale, Settings.GOLD_COLOR);
+        FontHelper.renderFontLeftDownAligned(sb, ExtraFonts.overlayTitleFont(), "Bestiary", startX + 79 * Settings.scale, 825.0f * Settings.scale, Settings.GOLD_COLOR);
 
         if (Config.requiresShift()) {
             RenderingUtils.renderSmartText(sb,
                     FontHelper.tipBodyFont,
                     "#mBestiary lets you see which moves a monster can use! NL NL Open up the overlay by #wShift #wRight #wClicking a monster while in combat. You can close this overlay with just a right click. NL NL Bestiary supports all vanilla mobs for all ascension levels. Please let me know on the Steam Workshop page or on the Github issues page if you find any problems. Thanks!",
-                    1133 * Settings.scale,
+                    Settings.WIDTH - startX - (471 * Settings.scale),
                     702 * Settings.scale,
                     400 * Settings.scale,
                     32 * Settings.scale,
@@ -68,7 +69,7 @@ public class AlternateConfigPanel extends ModPanel {
             RenderingUtils.renderSmartText(sb,
                     FontHelper.tipBodyFont,
                     "#mBestiary lets you see which moves a monster can use! NL NL Open up the overlay by #wRight #wClicking a monster while in combat. You can close this overlay with another right click. NL NL Bestiary supports all vanilla mobs for all ascension levels. Please let me know on the Steam Workshop page or on the Github issues page if you find any problems. Thanks!",
-                    1133 * Settings.scale,
+                    Settings.WIDTH - startX - (471 * Settings.scale),
                     702 * Settings.scale,
                     400 * Settings.scale,
                     32 * Settings.scale,

--- a/src/main/java/Bestiary/ui/MonsterInfoRenderHelper.java
+++ b/src/main/java/Bestiary/ui/MonsterInfoRenderHelper.java
@@ -26,7 +26,7 @@ public class MonsterInfoRenderHelper {
     // --------------------------------------------------------------------------------
     // UI layout information (WIP - to be tweaked as needed)
 
-    private static final float movesLeft = 315.0f;
+    private static final float movesLeft = MonsterOverlay.startX + (97 * Settings.scale);
     private static final float titleBottom = 886.0f;
 
     private static final float firstMoveBottom = 780.0f;
@@ -36,7 +36,7 @@ public class MonsterInfoRenderHelper {
     private static final float additionalMoveEffectPadding = 40.0f;
     private static final float moveEffectHorizSpacing = 50.0f;
 
-    private static final float descLeft = 1086.0f;
+    private static final float descLeft = Settings.WIDTH - MonsterOverlay.startX - (616 * Settings.scale);
     private static final float descTop = 847.0f;
     private static final float notesTop = 334.0f;
 

--- a/src/main/java/Bestiary/ui/MonsterOverlay.java
+++ b/src/main/java/Bestiary/ui/MonsterOverlay.java
@@ -11,6 +11,7 @@ import com.megacrit.cardcrawl.helpers.ImageMaster;
 
 public class MonsterOverlay {
     private static final Texture TEX_BG = new Texture("Bestiary/screen.png");
+    public static final float startX = (Settings.WIDTH - (TEX_BG.getWidth() * Settings.scale)) * 0.5f;
 
     private MonsterDatabase db;
     private MonsterInfoRenderHelper helper;
@@ -30,7 +31,7 @@ public class MonsterOverlay {
 
         sb.setColor(Color.WHITE);
         sb.draw(TEX_BG,
-                (Settings.WIDTH - (TEX_BG.getWidth() * Settings.scale)) * 0.5f,
+                startX,
                 (Settings.HEIGHT - (TEX_BG.getHeight() * Settings.scale)) * 0.5f,
                 TEX_BG.getWidth() * Settings.scale,
                 TEX_BG.getHeight() * Settings.scale


### PR DESCRIPTION
The current static pixel amounts are made for 1920x1080, on ultrawide this looks poorly as seen below. Using the current values, I worked out proper formulas so it scales correctly (horizontally) for ultrawide (2560x1080) - vertical stuff is unchanged so different heights may still have issues. Note that for 1920x1080, this does NOT change anything, I double checked the calculations, and compared screenshots from before and after the changes, it's identical, the change is only for other resolutions.

![image](https://user-images.githubusercontent.com/9139051/124369389-6340db80-dc63-11eb-9abb-77a2b94bd767.png)
![20210704002043_1](https://user-images.githubusercontent.com/9139051/124369484-22959200-dc64-11eb-85f6-5e9a1c21a6d2.jpg)