### PR TITLE
UI compatibility with Intent Graph

### DIFF
--- a/src/main/java/Bestiary/BestiaryMod.java
+++ b/src/main/java/Bestiary/BestiaryMod.java
@@ -8,6 +8,7 @@ import Bestiary.utils.SoundHelper;
 import basemod.BaseMod;
 import basemod.ReflectionHacks;
 import basemod.interfaces.PostInitializeSubscriber;
+import basemod.interfaces.PostRenderSubscriber;
 import basemod.interfaces.RenderSubscriber;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpireInitializer;
@@ -85,6 +86,9 @@ public class BestiaryMod implements PostInitializeSubscriber, RenderSubscriber {
         System.out.println("Currently hovered on: " + id);
         SoundHelper.openSound();
         overlay.setCurrMonsterByID(id);
+        AbstractRoom current_room = AbstractDungeon.getCurrRoom();
+        current_room.monsters.hoveredMonster = null;
+        current_room.monsters.monsters.forEach(m -> m.hb.unhover());
         showOverlay = true;
     }
 

--- a/src/main/java/Bestiary/patches/ScreenPatches.java
+++ b/src/main/java/Bestiary/patches/ScreenPatches.java
@@ -3,53 +3,70 @@ package Bestiary.patches;
 import Bestiary.BestiaryMod;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePrefixPatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpireReturn;
+import com.megacrit.cardcrawl.core.OverlayMenu;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.TipHelper;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.rooms.AbstractRoom;
+import com.megacrit.cardcrawl.scenes.AbstractScene;
+import com.megacrit.cardcrawl.screens.DrawPileViewScreen;
+import com.megacrit.cardcrawl.screens.DungeonMapScreen;
+import com.megacrit.cardcrawl.ui.FtueTip;
+import com.megacrit.cardcrawl.ui.buttons.DynamicBanner;
 import com.megacrit.cardcrawl.ui.panels.TopPanel;
 
 // Special thanks to blanktheevil (infinitespire)
 
 public class ScreenPatches {
-    @SpirePatch(
-            clz = TopPanel.class,
-            method = "update"
-    )
-    public static class TopPanelSuppressInputPatch {
-        @SpirePrefixPatch
-        public static SpireReturn<Void> Prefix(TopPanel __instance) {
-            if (BestiaryMod.showOverlay)
-                return SpireReturn.Return(null);
-            else
-                return SpireReturn.Continue();
-        }
-    }
 
-    @SpirePatch(
-            clz = TipHelper.class,
-            method = "render"
-    )
-    public static class TipSuppressorPatch {
-        @SpirePrefixPatch
-        public static SpireReturn<Void> Prefix(SpriteBatch sb) {
-            if (BestiaryMod.showOverlay)
-                return SpireReturn.Return(null);
-            else
-                return SpireReturn.Continue();
-        }
-    }
 
     @SpirePatch(
             clz = AbstractDungeon.class,
             method = "update"
     )
-    public static class AbstractDungeonUpdateSuppressPatch {
+    public static class AbstractDungeonUpdatePatch {
         @SpirePrefixPatch
-        public static SpireReturn<Void> Prefix(AbstractDungeon __instance) {
+        public static void Prefix() {
             BestiaryMod.update();
+        }
+    }
 
-            if (BestiaryMod.showOverlay)
+
+    @SpirePatch(
+        clz = AbstractRoom.class,
+        method = "update"
+    )
+    @SpirePatch(
+        clz = AbstractRoom.class,
+        method = "eventControllerInput"
+    )
+    @SpirePatch(
+        clz = AbstractScene.class,
+        method = "update"
+    )
+    @SpirePatch(
+        clz = TopPanel.class,
+        method = "update"
+    )
+    @SpirePatch(
+        clz = FtueTip.class,
+        method = "update"
+    )
+    @SpirePatch(
+        clz = DungeonMapScreen.class,
+        method = "update"
+    )
+    @SpirePatch(
+        clz = OverlayMenu.class,
+        method = "update"
+    )
+    public static class UpdateSuppressPatch {
+        @SpirePrefixPatch
+        public static SpireReturn<Void> Prefix() {
+            if (BestiaryMod.showOverlay) 
                 return SpireReturn.Return(null);
             else
                 return SpireReturn.Continue();


### PR DESCRIPTION
Makes Bestiary compatible with [Intent Graph](https://steamcommunity.com/sharedfiles/filedetails/?id=2783861904). 
Currently, derender of intent tooltip is prevented by AbtractRoom.update being completely ignored while bestiary overlay is open.

Selectively patches AbtractRoom.update and removes `hovered` state on all monsters on bestiary overlay trigger.